### PR TITLE
Fix roadmap files_exist property name

### DIFF
--- a/docs/roadmap.yml
+++ b/docs/roadmap.yml
@@ -8,5 +8,5 @@ weeks:
         name: "Repo + CI scaffolding"
         checks:
           - type: files_exist
-            files:
+            globs:
               - ".github/workflows/roadmap.yml"


### PR DESCRIPTION
## Summary
- rename the roadmap files_exist check to use the `globs` property required by the schema

## Testing
- node scripts/validate-roadmap.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cef070b0ac832d8ec01875d4191b56