### PR TITLE
Fix roadmap files_exist check config

### DIFF
--- a/docs/roadmap-status.json
+++ b/docs/roadmap-status.json
@@ -1,1 +1,24 @@
-{ "ok": true, "env": "dev", "generatedAt": "placeholder" }
+{
+  "generated_at": "2025-09-20T18:16:09.416Z",
+  "env": "dev",
+  "weeks": [
+    {
+      "title": "Weeks 1–2 — Foundations",
+      "id": "w01",
+      "items": [
+        {
+          "id": "repo-ci",
+          "name": "Repo + CI scaffolding",
+          "done": true,
+          "checks": [
+            {
+              "type": "files_exist",
+              "ok": true,
+              "detail": ".github/workflows/roadmap.yml"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/roadmap-status.md
+++ b/docs/roadmap-status.md
@@ -1,51 +1,6 @@
 # Roadmap Status
 
-Generated: 2025-09-13T21:34:01.394Z (env: dev)
+Generated: 2025-09-20T18:16:09.416Z (env: dev)
 
 ## Weeks 1–2 — Foundations
-- ✅ **CI & status scaffolding** (`infra-ci`)
-- ✅ **Secrets & safety guardrails in place** (`safety-basics`)
-
-## Weeks 3–4 — Read-only probes & GitHub App
-- ✅ **Supabase read_only_checks deployed** (`supa-probe`)
-- ❌ **GitHub App connected (PAT fallback allowed)** (`gh-app-installed`)
-
-## Weeks 5–6 — VS Code: assistant-safe context
-- ✅ **VS Code assistant configured (Continue/Cursor)** (`ide-config`)
-- ✅ **.chatignore covers secrets and noise** (`chatignore-coverage`)
-
-## Weeks 7–8 — Context Packs (auto)
-- ✅ **Context pack generated (code + docs index)** (`ctx-pack`)
-- ✅ **Context pack auto-refresh via CI** (`ctx-cron`)
-
-## Weeks 9–10 — PR automations
-- ✅ **PR merge comments summarize ✅/❌ flips** (`pr-flips`)
-- ❌ **Repo README shows live status badge** (`status-badge`)
-
-## Weeks 11–12 — DB facts surfaced (read-only)
-- ✅ **Auto-generated DB facts (tables, policies only)** (`db-facts`)
-- ✅ **DB facts refresh in CI** (`db-facts-ci`)
-
-## Weeks 13–14 — Tech stack truth & discovery
-- ✅ **tech-stack.yml curated and validated** (`tech-stack`)
-- ✅ **Off-roadmap discovery populates backlog** (`discover-work`)
-
-## Weeks 15–16 — Privacy & redaction
-- ❌ **Redaction rules defined (files/regex)** (`redaction-rules`)
-- ✅ **Redaction applied to context pack** (`redaction-enforced`)
-
-## Weeks 17–18 — Dashboard onboarding (multi-repo)
-- ✅ **Dashboard deployed (Vercel or similar)** (`dash-deployed`)
-- ✅ **Dashboard settings PR flow working** (`dash-settings`)
-
-## Weeks 19–20 — First-message context injection
-- ❌ **Assistant hints guide the model to use status** (`assistant-hints`)
-- ❌ **Preprompt includes context-pack & db-facts links** (`ctx-first-message`)
-
-## Weeks 21–22 — Security & reliability
-- ❌ **GitHub App only in prod (PAT disabled)** (`gh-app-only`)
-- ❌ **Minimal audit notes for context access** (`audit-logs`)
-
-## Weeks 23–24 — Packaging & docs
-- ❌ **New-repo bootstrap template published** (`repo-template`)
-- ❌ **One-pager: how to adopt in <30 min** (`one-pager`)
+- ✅ **Repo + CI scaffolding** (`repo-ci`)

--- a/docs/roadmap.yml
+++ b/docs/roadmap.yml
@@ -8,5 +8,5 @@ weeks:
         name: "Repo + CI scaffolding"
         checks:
           - type: files_exist
-            files:
+            globs:
               - ".github/workflows/roadmap.yml"


### PR DESCRIPTION
## Summary
- replace the roadmap `files_exist` check's `files` key with the supported `globs`
- regenerate the roadmap status artifacts so the dashboard shows the seeded week

## Testing
- npm run roadmap:check

------
https://chatgpt.com/codex/tasks/task_e_68ceebf6820c832da7629b171d4a250d